### PR TITLE
Updated dependency on scalajs-pickling-play-json

### DIFF
--- a/akka-websocket-bridge/build.sbt
+++ b/akka-websocket-bridge/build.sbt
@@ -13,5 +13,5 @@ resolvers += Resolver.url("scala-js-releases",
 libraryDependencies ++= Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.2.3",
     "com.typesafe.play" %% "play" % "2.2.1",
-    "org.scalajs" %% "scalajs-pickling-play-json" % "0.3-SNAPSHOT"
+    "org.scalajs" %% "scalajs-pickling-play-json" % "0.3"
 )

--- a/examples/chat-full-stack/build.sbt
+++ b/examples/chat-full-stack/build.sbt
@@ -9,5 +9,5 @@ name := "scalajs-actors-examples-chat"
 play.Project.playScalaSettings
 
 libraryDependencies ++= Seq(
-    "org.scalajs" %% "scalajs-pickling-play-json" % "0.3-SNAPSHOT"
+    "org.scalajs" %% "scalajs-pickling-play-json" % "0.3"
 )


### PR DESCRIPTION
I tried to run the examples but the scalajs-pickling-play-json dependency doesn't seem to be a snapshot anymore.
